### PR TITLE
Enable pretty printing for write function

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ function read(filename, maybeEncoding) {
 }
 
 function write(filename, data) {
-  return fs.writeFileSync(filename, JSON.stringify(data));
+  return fs.writeFileSync(filename, JSON.stringify(data, null, 2));
 }
 
 module.exports = {


### PR DESCRIPTION
Pretty-printing is implemented natively in JSON.stringify(). The third argument enables pretty printing and sets the spacing to use to 2 whitespaces.

webppl-json % webppl test.wppl --require .
Test passed: true

Maybe you want to keep pretty-printing optional because of increased storage space of the results files, let me know then I can update the PR to be optional.